### PR TITLE
Freddy(Feature): CodeParsingService and Tests

### DIFF
--- a/src/CodeSleuth.Core/CodeSleuth.Core.csproj
+++ b/src/CodeSleuth.Core/CodeSleuth.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CodeSleuth.Core/Models/CodeChunk.cs
+++ b/src/CodeSleuth.Core/Models/CodeChunk.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace CodeSleuth.Core.Models;
+
+/// <summary>
+/// Represents a semantic chunk of code extracted from a source file.
+/// </summary>
+public class CodeChunk
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for this code chunk.
+    /// </summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Gets or sets the type of code element.
+    /// Valid values: "class", "method", "interface", "property", "constructor", "field", "enum"
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the code element.
+    /// For methods, this will be the qualified name like "ClassName.MethodName".
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the full source code content of this element.
+    /// </summary>
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file path where this code chunk was found.
+    /// </summary>
+    public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the starting line number of this code chunk in the source file.
+    /// </summary>
+    public int StartLine { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ending line number of this code chunk in the source file.
+    /// </summary>
+    public int EndLine { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the parent element (e.g., containing class for methods).
+    /// </summary>
+    public string? ParentName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the namespace containing this code element.
+    /// </summary>
+    public string? Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of dependencies (using statements, referenced types, etc.).
+    /// </summary>
+    public List<string> Dependencies { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the access modifiers for this code element.
+    /// </summary>
+    public string? AccessModifiers { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional metadata about this code chunk.
+    /// </summary>
+    public Dictionary<string, object> Metadata { get; set; } = new();
+
+    /// <summary>
+    /// Returns a string representation of this code chunk.
+    /// </summary>
+    public override string ToString()
+    {
+        var parentInfo = !string.IsNullOrEmpty(ParentName) ? $" (in {ParentName})" : "";
+        var namespaceInfo = !string.IsNullOrEmpty(Namespace) ? $" [{Namespace}]" : "";
+        return $"{Type}: {Name}{parentInfo}{namespaceInfo} - Lines {StartLine}-{EndLine}";
+    }
+}

--- a/src/CodeSleuth.Core/Services/CodeParsingService.cs
+++ b/src/CodeSleuth.Core/Services/CodeParsingService.cs
@@ -1,0 +1,755 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
+using CodeSleuth.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CodeSleuth.Core.Services;
+
+/// <summary>
+/// Custom exception for code parsing operations.
+/// </summary>
+public class CodeParsingException : Exception
+{
+    public CodeParsingException(string message) : base(message) { }
+    public CodeParsingException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Service for parsing C# source code into semantic chunks using Roslyn.
+/// Extracts classes, methods, interfaces, properties, and other code elements.
+/// </summary>
+public class CodeParsingService
+{
+    private readonly ILogger<CodeParsingService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the CodeParsingService class.
+    /// </summary>
+    /// <param name="logger">The logger instance for logging operations.</param>
+    /// <exception cref="ArgumentNullException">Thrown when logger is null.</exception>
+    public CodeParsingService(ILogger<CodeParsingService> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger.LogInformation("CodeParsingService initialized");
+    }
+
+    /// <summary>
+    /// Parses a C# source file and extracts semantic code chunks.
+    /// </summary>
+    /// <param name="filePath">The path to the C# file to parse.</param>
+    /// <returns>A list of code chunks extracted from the file.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the file doesn't exist.</exception>
+    /// <exception cref="CodeParsingException">Thrown when parsing fails.</exception>
+    public List<CodeChunk> ParseCSharpFile(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentNullException(nameof(filePath));
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File does not exist: {filePath}");
+
+        try
+        {
+            _logger.LogDebug("Parsing C# file: {FilePath}", filePath);
+
+            var sourceText = File.ReadAllText(filePath);
+            var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, path: filePath);
+            var root = syntaxTree.GetCompilationUnitRoot();
+
+            // Check for syntax errors
+            var diagnostics = syntaxTree.GetDiagnostics()
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .ToList();
+
+            if (diagnostics.Any())
+            {
+                _logger.LogWarning("Syntax errors found in {FilePath}: {ErrorCount} errors", 
+                    filePath, diagnostics.Count);
+                
+                foreach (var diagnostic in diagnostics.Take(5)) // Log first 5 errors
+                {
+                    _logger.LogWarning("Syntax error: {Message} at {Location}", 
+                        diagnostic.GetMessage(), diagnostic.Location);
+                }
+
+                // Continue parsing despite errors, but log them
+            }
+
+            var chunks = new List<CodeChunk>();
+            var context = new ParsingContext(filePath, sourceText, syntaxTree);
+
+            // Extract using directives for dependencies
+            var usings = root.Usings.Select(u => u.Name?.ToString() ?? "").Where(s => !string.IsNullOrEmpty(s)).ToList();
+
+            // Parse namespace declarations
+            foreach (var namespaceDeclaration in root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>())
+            {
+                ParseNamespaceDeclaration(namespaceDeclaration, context, chunks, usings);
+            }
+
+            // Parse top-level declarations (for file-scoped namespaces or global declarations)
+            ParseTopLevelDeclarations(root, context, chunks, usings, null);
+
+            _logger.LogInformation("Successfully parsed {FilePath}: {ChunkCount} chunks extracted", 
+                filePath, chunks.Count);
+
+            return chunks;
+        }
+        catch (Exception ex) when (!(ex is ArgumentNullException or FileNotFoundException))
+        {
+            _logger.LogError(ex, "Failed to parse C# file: {FilePath}", filePath);
+            throw new CodeParsingException($"Failed to parse C# file '{filePath}': {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Parses declarations within a namespace.
+    /// </summary>
+    private void ParseNamespaceDeclaration(BaseNamespaceDeclarationSyntax namespaceDeclaration, 
+        ParsingContext context, List<CodeChunk> chunks, List<string> usings)
+    {
+        var namespaceName = namespaceDeclaration.Name.ToString();
+        _logger.LogTrace("Parsing namespace: {NamespaceName}", namespaceName);
+
+        ParseTopLevelDeclarations(namespaceDeclaration, context, chunks, usings, namespaceName);
+    }
+
+    /// <summary>
+    /// Parses top-level declarations (classes, interfaces, enums, etc.).
+    /// </summary>
+    private void ParseTopLevelDeclarations(SyntaxNode parent, ParsingContext context, 
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName)
+    {
+        var typeDeclarations = parent.ChildNodes().OfType<BaseTypeDeclarationSyntax>();
+
+        foreach (var typeDeclaration in typeDeclarations)
+        {
+            switch (typeDeclaration)
+            {
+                case ClassDeclarationSyntax classDecl:
+                    ParseClassDeclaration(classDecl, context, chunks, usings, namespaceName);
+                    break;
+                case InterfaceDeclarationSyntax interfaceDecl:
+                    ParseInterfaceDeclaration(interfaceDecl, context, chunks, usings, namespaceName);
+                    break;
+                case StructDeclarationSyntax structDecl:
+                    ParseStructDeclaration(structDecl, context, chunks, usings, namespaceName);
+                    break;
+                case EnumDeclarationSyntax enumDecl:
+                    ParseEnumDeclaration(enumDecl, context, chunks, usings, namespaceName);
+                    break;
+                case RecordDeclarationSyntax recordDecl:
+                    ParseRecordDeclaration(recordDecl, context, chunks, usings, namespaceName);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses a class declaration and its members.
+    /// </summary>
+    private void ParseClassDeclaration(ClassDeclarationSyntax classDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName)
+    {
+        var className = classDeclaration.Identifier.ValueText;
+        var qualifiedClassName = !string.IsNullOrEmpty(namespaceName) ? $"{namespaceName}.{className}" : className;
+
+        _logger.LogTrace("Parsing class: {ClassName}", qualifiedClassName);
+
+        // Create chunk for the class itself
+        var classChunk = CreateCodeChunk(
+            type: "class",
+            name: qualifiedClassName,
+            content: classDeclaration.ToString(),
+            context: context,
+            syntaxNode: classDeclaration,
+            namespaceName: namespaceName,
+            parentName: null,
+            dependencies: usings
+        );
+
+        classChunk.AccessModifiers = GetAccessModifiers(classDeclaration.Modifiers);
+        chunks.Add(classChunk);
+
+        // Parse class members
+        ParseClassMembers(classDeclaration, context, chunks, usings, namespaceName, className);
+    }
+
+    /// <summary>
+    /// Parses members within a class.
+    /// </summary>
+    private void ParseClassMembers(BaseTypeDeclarationSyntax typeDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string typeName)
+    {
+        // Cast to TypeDeclarationSyntax to access Members
+        if (typeDeclaration is not TypeDeclarationSyntax typeDecl)
+            return;
+
+        foreach (var member in typeDecl.Members)
+        {
+            switch (member)
+            {
+                case MethodDeclarationSyntax method:
+                    ParseMethodDeclaration(method, context, chunks, usings, namespaceName, typeName);
+                    break;
+                case PropertyDeclarationSyntax property:
+                    ParsePropertyDeclaration(property, context, chunks, usings, namespaceName, typeName);
+                    break;
+                case ConstructorDeclarationSyntax constructor:
+                    ParseConstructorDeclaration(constructor, context, chunks, usings, namespaceName, typeName);
+                    break;
+                case FieldDeclarationSyntax field:
+                    ParseFieldDeclaration(field, context, chunks, usings, namespaceName, typeName);
+                    break;
+                case EventDeclarationSyntax eventDecl:
+                    ParseEventDeclaration(eventDecl, context, chunks, usings, namespaceName, typeName);
+                    break;
+                case EventFieldDeclarationSyntax eventField:
+                    ParseEventFieldDeclaration(eventField, context, chunks, usings, namespaceName, typeName);
+                    break;
+                case IndexerDeclarationSyntax indexer:
+                    ParseIndexerDeclaration(indexer, context, chunks, usings, namespaceName, typeName);
+                    break;
+                // Handle nested types
+                case BaseTypeDeclarationSyntax nestedType:
+                    ParseNestedTypeDeclaration(nestedType, context, chunks, usings, namespaceName, typeName);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses a method declaration.
+    /// </summary>
+    private void ParseMethodDeclaration(MethodDeclarationSyntax methodDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var methodName = methodDeclaration.Identifier.ValueText;
+        var qualifiedMethodName = $"{parentName}.{methodName}";
+
+        var methodChunk = CreateCodeChunk(
+            type: "method",
+            name: qualifiedMethodName,
+            content: methodDeclaration.ToString(),
+            context: context,
+            syntaxNode: methodDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        methodChunk.AccessModifiers = GetAccessModifiers(methodDeclaration.Modifiers);
+        
+        // Add parameter types to metadata
+        var parameters = methodDeclaration.ParameterList.Parameters
+            .Select(p => p.Type?.ToString() ?? "unknown")
+            .ToList();
+        
+        if (parameters.Any())
+        {
+            methodChunk.Metadata["Parameters"] = parameters;
+        }
+
+        // Add return type to metadata
+        methodChunk.Metadata["ReturnType"] = methodDeclaration.ReturnType.ToString();
+
+        chunks.Add(methodChunk);
+    }
+
+    /// <summary>
+    /// Parses a property declaration.
+    /// </summary>
+    private void ParsePropertyDeclaration(PropertyDeclarationSyntax propertyDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var propertyName = propertyDeclaration.Identifier.ValueText;
+        var qualifiedPropertyName = $"{parentName}.{propertyName}";
+
+        var propertyChunk = CreateCodeChunk(
+            type: "property",
+            name: qualifiedPropertyName,
+            content: propertyDeclaration.ToString(),
+            context: context,
+            syntaxNode: propertyDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        propertyChunk.AccessModifiers = GetAccessModifiers(propertyDeclaration.Modifiers);
+        propertyChunk.Metadata["PropertyType"] = propertyDeclaration.Type.ToString();
+
+        chunks.Add(propertyChunk);
+    }
+
+    /// <summary>
+    /// Parses a constructor declaration.
+    /// </summary>
+    private void ParseConstructorDeclaration(ConstructorDeclarationSyntax constructorDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var qualifiedConstructorName = $"{parentName}..ctor";
+
+        var constructorChunk = CreateCodeChunk(
+            type: "constructor",
+            name: qualifiedConstructorName,
+            content: constructorDeclaration.ToString(),
+            context: context,
+            syntaxNode: constructorDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        constructorChunk.AccessModifiers = GetAccessModifiers(constructorDeclaration.Modifiers);
+
+        // Add parameter types to metadata
+        var parameters = constructorDeclaration.ParameterList.Parameters
+            .Select(p => p.Type?.ToString() ?? "unknown")
+            .ToList();
+        
+        if (parameters.Any())
+        {
+            constructorChunk.Metadata["Parameters"] = parameters;
+        }
+
+        chunks.Add(constructorChunk);
+    }
+
+    /// <summary>
+    /// Parses a field declaration.
+    /// </summary>
+    private void ParseFieldDeclaration(FieldDeclarationSyntax fieldDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        foreach (var variable in fieldDeclaration.Declaration.Variables)
+        {
+            var fieldName = variable.Identifier.ValueText;
+            var qualifiedFieldName = $"{parentName}.{fieldName}";
+
+            var fieldChunk = CreateCodeChunk(
+                type: "field",
+                name: qualifiedFieldName,
+                content: fieldDeclaration.ToString(),
+                context: context,
+                syntaxNode: fieldDeclaration,
+                namespaceName: namespaceName,
+                parentName: parentName,
+                dependencies: usings
+            );
+
+            fieldChunk.AccessModifiers = GetAccessModifiers(fieldDeclaration.Modifiers);
+            fieldChunk.Metadata["FieldType"] = fieldDeclaration.Declaration.Type.ToString();
+
+            chunks.Add(fieldChunk);
+        }
+    }
+
+    /// <summary>
+    /// Parses an event declaration.
+    /// </summary>
+    private void ParseEventDeclaration(EventDeclarationSyntax eventDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var eventName = eventDeclaration.Identifier.ValueText;
+        var qualifiedEventName = $"{parentName}.{eventName}";
+
+        var eventChunk = CreateCodeChunk(
+            type: "event",
+            name: qualifiedEventName,
+            content: eventDeclaration.ToString(),
+            context: context,
+            syntaxNode: eventDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        eventChunk.AccessModifiers = GetAccessModifiers(eventDeclaration.Modifiers);
+        eventChunk.Metadata["EventType"] = eventDeclaration.Type.ToString();
+
+        chunks.Add(eventChunk);
+    }
+
+    /// <summary>
+    /// Parses an event field declaration (e.g., public event EventHandler MyEvent;).
+    /// </summary>
+    private void ParseEventFieldDeclaration(EventFieldDeclarationSyntax eventFieldDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        foreach (var variable in eventFieldDeclaration.Declaration.Variables)
+        {
+            var eventName = variable.Identifier.ValueText;
+            var qualifiedEventName = $"{parentName}.{eventName}";
+
+            var eventChunk = CreateCodeChunk(
+                type: "event",
+                name: qualifiedEventName,
+                content: eventFieldDeclaration.ToString(),
+                context: context,
+                syntaxNode: eventFieldDeclaration,
+                namespaceName: namespaceName,
+                parentName: parentName,
+                dependencies: usings
+            );
+
+            eventChunk.AccessModifiers = GetAccessModifiers(eventFieldDeclaration.Modifiers);
+            eventChunk.Metadata["EventType"] = eventFieldDeclaration.Declaration.Type.ToString();
+
+            chunks.Add(eventChunk);
+        }
+    }
+
+    /// <summary>
+    /// Parses an indexer declaration.
+    /// </summary>
+    private void ParseIndexerDeclaration(IndexerDeclarationSyntax indexerDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var qualifiedIndexerName = $"{parentName}.this[]";
+
+        var indexerChunk = CreateCodeChunk(
+            type: "indexer",
+            name: qualifiedIndexerName,
+            content: indexerDeclaration.ToString(),
+            context: context,
+            syntaxNode: indexerDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        indexerChunk.AccessModifiers = GetAccessModifiers(indexerDeclaration.Modifiers);
+        indexerChunk.Metadata["IndexerType"] = indexerDeclaration.Type.ToString();
+
+        chunks.Add(indexerChunk);
+    }
+
+    /// <summary>
+    /// Parses an interface declaration.
+    /// </summary>
+    private void ParseInterfaceDeclaration(InterfaceDeclarationSyntax interfaceDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName)
+    {
+        var interfaceName = interfaceDeclaration.Identifier.ValueText;
+        var qualifiedInterfaceName = !string.IsNullOrEmpty(namespaceName) ? $"{namespaceName}.{interfaceName}" : interfaceName;
+
+        var interfaceChunk = CreateCodeChunk(
+            type: "interface",
+            name: qualifiedInterfaceName,
+            content: interfaceDeclaration.ToString(),
+            context: context,
+            syntaxNode: interfaceDeclaration,
+            namespaceName: namespaceName,
+            parentName: null,
+            dependencies: usings
+        );
+
+        interfaceChunk.AccessModifiers = GetAccessModifiers(interfaceDeclaration.Modifiers);
+        chunks.Add(interfaceChunk);
+
+        // Parse interface members
+        ParseClassMembers(interfaceDeclaration, context, chunks, usings, namespaceName, interfaceName);
+    }
+
+    /// <summary>
+    /// Parses a struct declaration.
+    /// </summary>
+    private void ParseStructDeclaration(StructDeclarationSyntax structDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName)
+    {
+        var structName = structDeclaration.Identifier.ValueText;
+        var qualifiedStructName = !string.IsNullOrEmpty(namespaceName) ? $"{namespaceName}.{structName}" : structName;
+
+        var structChunk = CreateCodeChunk(
+            type: "struct",
+            name: qualifiedStructName,
+            content: structDeclaration.ToString(),
+            context: context,
+            syntaxNode: structDeclaration,
+            namespaceName: namespaceName,
+            parentName: null,
+            dependencies: usings
+        );
+
+        structChunk.AccessModifiers = GetAccessModifiers(structDeclaration.Modifiers);
+        chunks.Add(structChunk);
+
+        // Parse struct members
+        ParseClassMembers(structDeclaration, context, chunks, usings, namespaceName, structName);
+    }
+
+    /// <summary>
+    /// Parses an enum declaration.
+    /// </summary>
+    private void ParseEnumDeclaration(EnumDeclarationSyntax enumDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName)
+    {
+        var enumName = enumDeclaration.Identifier.ValueText;
+        var qualifiedEnumName = !string.IsNullOrEmpty(namespaceName) ? $"{namespaceName}.{enumName}" : enumName;
+
+        var enumChunk = CreateCodeChunk(
+            type: "enum",
+            name: qualifiedEnumName,
+            content: enumDeclaration.ToString(),
+            context: context,
+            syntaxNode: enumDeclaration,
+            namespaceName: namespaceName,
+            parentName: null,
+            dependencies: usings
+        );
+
+        enumChunk.AccessModifiers = GetAccessModifiers(enumDeclaration.Modifiers);
+        
+        // Add enum values to metadata
+        var enumValues = enumDeclaration.Members.Select(m => m.Identifier.ValueText).ToList();
+        if (enumValues.Any())
+        {
+            enumChunk.Metadata["EnumValues"] = enumValues;
+        }
+
+        chunks.Add(enumChunk);
+    }
+
+    /// <summary>
+    /// Parses a record declaration.
+    /// </summary>
+    private void ParseRecordDeclaration(RecordDeclarationSyntax recordDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName)
+    {
+        var recordName = recordDeclaration.Identifier.ValueText;
+        var qualifiedRecordName = !string.IsNullOrEmpty(namespaceName) ? $"{namespaceName}.{recordName}" : recordName;
+
+        var recordChunk = CreateCodeChunk(
+            type: "record",
+            name: qualifiedRecordName,
+            content: recordDeclaration.ToString(),
+            context: context,
+            syntaxNode: recordDeclaration,
+            namespaceName: namespaceName,
+            parentName: null,
+            dependencies: usings
+        );
+
+        recordChunk.AccessModifiers = GetAccessModifiers(recordDeclaration.Modifiers);
+        chunks.Add(recordChunk);
+
+        // Parse record members
+        ParseClassMembers(recordDeclaration, context, chunks, usings, namespaceName, recordName);
+    }
+
+    /// <summary>
+    /// Parses nested type declarations.
+    /// </summary>
+    private void ParseNestedTypeDeclaration(BaseTypeDeclarationSyntax nestedTypeDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        switch (nestedTypeDeclaration)
+        {
+            case ClassDeclarationSyntax nestedClass:
+                ParseNestedClassDeclaration(nestedClass, context, chunks, usings, namespaceName, parentName);
+                break;
+            case InterfaceDeclarationSyntax nestedInterface:
+                ParseNestedInterfaceDeclaration(nestedInterface, context, chunks, usings, namespaceName, parentName);
+                break;
+            case StructDeclarationSyntax nestedStruct:
+                ParseNestedStructDeclaration(nestedStruct, context, chunks, usings, namespaceName, parentName);
+                break;
+            case EnumDeclarationSyntax nestedEnum:
+                ParseNestedEnumDeclaration(nestedEnum, context, chunks, usings, namespaceName, parentName);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Parses a nested class declaration.
+    /// </summary>
+    private void ParseNestedClassDeclaration(ClassDeclarationSyntax nestedClassDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var nestedClassName = nestedClassDeclaration.Identifier.ValueText;
+        var qualifiedNestedClassName = $"{parentName}.{nestedClassName}";
+
+        var nestedClassChunk = CreateCodeChunk(
+            type: "class",
+            name: qualifiedNestedClassName,
+            content: nestedClassDeclaration.ToString(),
+            context: context,
+            syntaxNode: nestedClassDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        nestedClassChunk.AccessModifiers = GetAccessModifiers(nestedClassDeclaration.Modifiers);
+        chunks.Add(nestedClassChunk);
+
+        // Parse nested class members
+        ParseClassMembers(nestedClassDeclaration, context, chunks, usings, namespaceName, qualifiedNestedClassName);
+    }
+
+    /// <summary>
+    /// Parses a nested interface declaration.
+    /// </summary>
+    private void ParseNestedInterfaceDeclaration(InterfaceDeclarationSyntax nestedInterfaceDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var nestedInterfaceName = nestedInterfaceDeclaration.Identifier.ValueText;
+        var qualifiedNestedInterfaceName = $"{parentName}.{nestedInterfaceName}";
+
+        var nestedInterfaceChunk = CreateCodeChunk(
+            type: "interface",
+            name: qualifiedNestedInterfaceName,
+            content: nestedInterfaceDeclaration.ToString(),
+            context: context,
+            syntaxNode: nestedInterfaceDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        nestedInterfaceChunk.AccessModifiers = GetAccessModifiers(nestedInterfaceDeclaration.Modifiers);
+        chunks.Add(nestedInterfaceChunk);
+
+        // Parse nested interface members
+        ParseClassMembers(nestedInterfaceDeclaration, context, chunks, usings, namespaceName, qualifiedNestedInterfaceName);
+    }
+
+    /// <summary>
+    /// Parses a nested struct declaration.
+    /// </summary>
+    private void ParseNestedStructDeclaration(StructDeclarationSyntax nestedStructDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var nestedStructName = nestedStructDeclaration.Identifier.ValueText;
+        var qualifiedNestedStructName = $"{parentName}.{nestedStructName}";
+
+        var nestedStructChunk = CreateCodeChunk(
+            type: "struct",
+            name: qualifiedNestedStructName,
+            content: nestedStructDeclaration.ToString(),
+            context: context,
+            syntaxNode: nestedStructDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        nestedStructChunk.AccessModifiers = GetAccessModifiers(nestedStructDeclaration.Modifiers);
+        chunks.Add(nestedStructChunk);
+
+        // Parse nested struct members
+        ParseClassMembers(nestedStructDeclaration, context, chunks, usings, namespaceName, qualifiedNestedStructName);
+    }
+
+    /// <summary>
+    /// Parses a nested enum declaration.
+    /// </summary>
+    private void ParseNestedEnumDeclaration(EnumDeclarationSyntax nestedEnumDeclaration, ParsingContext context,
+        List<CodeChunk> chunks, List<string> usings, string? namespaceName, string parentName)
+    {
+        var nestedEnumName = nestedEnumDeclaration.Identifier.ValueText;
+        var qualifiedNestedEnumName = $"{parentName}.{nestedEnumName}";
+
+        var nestedEnumChunk = CreateCodeChunk(
+            type: "enum",
+            name: qualifiedNestedEnumName,
+            content: nestedEnumDeclaration.ToString(),
+            context: context,
+            syntaxNode: nestedEnumDeclaration,
+            namespaceName: namespaceName,
+            parentName: parentName,
+            dependencies: usings
+        );
+
+        nestedEnumChunk.AccessModifiers = GetAccessModifiers(nestedEnumDeclaration.Modifiers);
+        
+        // Add enum values to metadata
+        var enumValues = nestedEnumDeclaration.Members.Select(m => m.Identifier.ValueText).ToList();
+        if (enumValues.Any())
+        {
+            nestedEnumChunk.Metadata["EnumValues"] = enumValues;
+        }
+
+        chunks.Add(nestedEnumChunk);
+    }
+
+    /// <summary>
+    /// Creates a code chunk with common properties.
+    /// </summary>
+    private CodeChunk CreateCodeChunk(string type, string name, string content, ParsingContext context,
+        SyntaxNode syntaxNode, string? namespaceName, string? parentName, List<string> dependencies)
+    {
+        var location = syntaxNode.GetLocation();
+        var lineSpan = location.GetLineSpan();
+
+        return new CodeChunk
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            Name = name,
+            Content = content,
+            FilePath = context.FilePath,
+            StartLine = lineSpan.StartLinePosition.Line + 1, // Convert to 1-based line numbers
+            EndLine = lineSpan.EndLinePosition.Line + 1,
+            ParentName = parentName,
+            Namespace = namespaceName,
+            Dependencies = new List<string>(dependencies)
+        };
+    }
+
+    /// <summary>
+    /// Extracts access modifiers from a syntax token list.
+    /// </summary>
+    private static string GetAccessModifiers(SyntaxTokenList modifiers)
+    {
+        var accessModifiers = modifiers
+            .Where(token => token.IsKind(SyntaxKind.PublicKeyword) ||
+                           token.IsKind(SyntaxKind.PrivateKeyword) ||
+                           token.IsKind(SyntaxKind.ProtectedKeyword) ||
+                           token.IsKind(SyntaxKind.InternalKeyword) ||
+                           token.IsKind(SyntaxKind.StaticKeyword) ||
+                           token.IsKind(SyntaxKind.AbstractKeyword) ||
+                           token.IsKind(SyntaxKind.VirtualKeyword) ||
+                           token.IsKind(SyntaxKind.OverrideKeyword) ||
+                           token.IsKind(SyntaxKind.SealedKeyword) ||
+                           token.IsKind(SyntaxKind.ReadOnlyKeyword) ||
+                           token.IsKind(SyntaxKind.ConstKeyword))
+            .Select(token => token.ValueText)
+            .ToList();
+
+        return string.Join(" ", accessModifiers);
+    }
+
+    /// <summary>
+    /// Gets information about the current parsing service configuration.
+    /// </summary>
+    /// <returns>Configuration information for debugging purposes.</returns>
+    public string GetConfigurationInfo()
+    {
+        return "CodeParsingService - Using Microsoft.CodeAnalysis.CSharp (Roslyn) for C# parsing";
+    }
+}
+
+/// <summary>
+/// Context information for parsing operations.
+/// </summary>
+internal class ParsingContext
+{
+    public string FilePath { get; }
+    public string SourceText { get; }
+    public SyntaxTree SyntaxTree { get; }
+
+    public ParsingContext(string filePath, string sourceText, SyntaxTree syntaxTree)
+    {
+        FilePath = filePath;
+        SourceText = sourceText;
+        SyntaxTree = syntaxTree;
+    }
+}

--- a/tests/CodeSleuth.Tests.Unit/CodeSleuth.Tests.Unit.csproj
+++ b/tests/CodeSleuth.Tests.Unit/CodeSleuth.Tests.Unit.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CodeSleuth.Infrastructure\CodeSleuth.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\CodeSleuth.Core\CodeSleuth.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CodeSleuth.Tests.Unit/Core/Services/CodeParsingServiceTests.cs
+++ b/tests/CodeSleuth.Tests.Unit/Core/Services/CodeParsingServiceTests.cs
@@ -1,0 +1,597 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using CodeSleuth.Core.Services;
+using CodeSleuth.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CodeSleuth.Tests.Unit.Core.Services;
+
+public class CodeParsingServiceTests : IDisposable
+{
+    private readonly Mock<ILogger<CodeParsingService>> _mockLogger;
+    private readonly CodeParsingService _codeParsingService;
+    private readonly string _testFilesDirectory;
+
+    public CodeParsingServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<CodeParsingService>>();
+        _codeParsingService = new CodeParsingService(_mockLogger.Object);
+        _testFilesDirectory = Path.Combine(Path.GetTempPath(), "CodeParsingServiceTests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testFilesDirectory);
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new CodeParsingService(null!));
+    }
+
+    [Fact]
+    public void Constructor_WithValidLogger_ShouldInitializeCorrectly()
+    {
+        // Arrange & Act
+        var service = new CodeParsingService(_mockLogger.Object);
+
+        // Assert
+        Assert.NotNull(service);
+        var configInfo = service.GetConfigurationInfo();
+        Assert.Contains("CodeParsingService", configInfo);
+        Assert.Contains("Roslyn", configInfo);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithNullFilePath_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _codeParsingService.ParseCSharpFile(null!));
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithEmptyFilePath_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _codeParsingService.ParseCSharpFile(""));
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithNonExistentFile_ShouldThrowFileNotFoundException()
+    {
+        // Arrange
+        const string nonExistentFile = "/path/that/does/not/exist.cs";
+
+        // Act & Assert
+        Assert.Throws<FileNotFoundException>(() => _codeParsingService.ParseCSharpFile(nonExistentFile));
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithSimpleClass_ShouldExtractClassChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            Console.WriteLine(""Hello World"");
+        }
+    }
+}";
+        var testFile = CreateTestFile("SimpleClass.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        Assert.NotNull(chunks);
+        Assert.NotEmpty(chunks);
+
+        var classChunk = chunks.FirstOrDefault(c => c.Type == "class");
+        Assert.NotNull(classChunk);
+        Assert.Equal("TestNamespace.TestClass", classChunk.Name);
+        Assert.Equal("TestNamespace", classChunk.Namespace);
+        Assert.Null(classChunk.ParentName);
+        Assert.Equal("public", classChunk.AccessModifiers);
+        Assert.Contains("System", classChunk.Dependencies);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithMethodInClass_ShouldExtractMethodChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(string parameter)
+        {
+            Console.WriteLine(parameter);
+        }
+
+        private int Calculate(int a, int b)
+        {
+            return a + b;
+        }
+    }
+}";
+        var testFile = CreateTestFile("ClassWithMethods.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var methodChunks = chunks.Where(c => c.Type == "method").ToList();
+        Assert.Equal(2, methodChunks.Count);
+
+        var testMethodChunk = methodChunks.FirstOrDefault(c => c.Name == "TestClass.TestMethod");
+        Assert.NotNull(testMethodChunk);
+        Assert.Equal("TestNamespace", testMethodChunk.Namespace);
+        Assert.Equal("TestClass", testMethodChunk.ParentName);
+        Assert.Equal("public", testMethodChunk.AccessModifiers);
+        Assert.Contains("void", testMethodChunk.Content);
+
+        var calculateMethodChunk = methodChunks.FirstOrDefault(c => c.Name == "TestClass.Calculate");
+        Assert.NotNull(calculateMethodChunk);
+        Assert.Equal("private", calculateMethodChunk.AccessModifiers);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithInterface_ShouldExtractInterfaceChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public interface ITestInterface
+    {
+        void DoSomething();
+        string GetValue();
+    }
+}";
+        var testFile = CreateTestFile("TestInterface.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var interfaceChunk = chunks.FirstOrDefault(c => c.Type == "interface");
+        Assert.NotNull(interfaceChunk);
+        Assert.Equal("TestNamespace.ITestInterface", interfaceChunk.Name);
+        Assert.Equal("TestNamespace", interfaceChunk.Namespace);
+        Assert.Equal("public", interfaceChunk.AccessModifiers);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithProperties_ShouldExtractPropertyChunks()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public string Name { get; set; }
+        
+        private int _age;
+        public int Age 
+        { 
+            get => _age; 
+            set => _age = value; 
+        }
+
+        public static readonly string StaticProperty = ""test"";
+    }
+}";
+        var testFile = CreateTestFile("ClassWithProperties.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var propertyChunks = chunks.Where(c => c.Type == "property").ToList();
+        Assert.Equal(2, propertyChunks.Count);
+
+        var nameProperty = propertyChunks.FirstOrDefault(c => c.Name == "TestClass.Name");
+        Assert.NotNull(nameProperty);
+        Assert.Equal("public", nameProperty.AccessModifiers);
+        Assert.Equal("TestClass", nameProperty.ParentName);
+
+        var ageProperty = propertyChunks.FirstOrDefault(c => c.Name == "TestClass.Age");
+        Assert.NotNull(ageProperty);
+        Assert.Equal("public", ageProperty.AccessModifiers);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithConstructor_ShouldExtractConstructorChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public TestClass()
+        {
+        }
+
+        public TestClass(string name, int age)
+        {
+            Name = name;
+            Age = age;
+        }
+
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+}";
+        var testFile = CreateTestFile("ClassWithConstructors.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var constructorChunks = chunks.Where(c => c.Type == "constructor").ToList();
+        Assert.Equal(2, constructorChunks.Count);
+
+        var defaultConstructor = constructorChunks.FirstOrDefault(c => c.Content.Contains("TestClass()"));
+        Assert.NotNull(defaultConstructor);
+        Assert.Equal("TestClass..ctor", defaultConstructor.Name);
+        Assert.Equal("TestClass", defaultConstructor.ParentName);
+        Assert.Equal("public", defaultConstructor.AccessModifiers);
+
+        var parameterizedConstructor = constructorChunks.FirstOrDefault(c => c.Content.Contains("string name"));
+        Assert.NotNull(parameterizedConstructor);
+        Assert.Equal("public", parameterizedConstructor.AccessModifiers);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithField_ShouldExtractFieldChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        private string _name;
+        public static readonly int MaxValue = 100;
+        private const string DefaultName = ""Default"";
+    }
+}";
+        var testFile = CreateTestFile("ClassWithFields.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var fieldChunks = chunks.Where(c => c.Type == "field").ToList();
+        Assert.Equal(3, fieldChunks.Count);
+
+        var nameField = fieldChunks.FirstOrDefault(c => c.Name == "TestClass._name");
+        Assert.NotNull(nameField);
+        Assert.Equal("private", nameField.AccessModifiers);
+
+        var maxValueField = fieldChunks.FirstOrDefault(c => c.Name == "TestClass.MaxValue");
+        Assert.NotNull(maxValueField);
+        Assert.Contains("static", maxValueField.AccessModifiers);
+        Assert.Contains("readonly", maxValueField.AccessModifiers);
+
+        var defaultNameField = fieldChunks.FirstOrDefault(c => c.Name == "TestClass.DefaultName");
+        Assert.NotNull(defaultNameField);
+        Assert.Contains("const", defaultNameField.AccessModifiers);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithEnum_ShouldExtractEnumChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public enum Status
+    {
+        Active,
+        Inactive,
+        Pending
+    }
+}";
+        var testFile = CreateTestFile("TestEnum.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var enumChunk = chunks.FirstOrDefault(c => c.Type == "enum");
+        Assert.NotNull(enumChunk);
+        Assert.Equal("TestNamespace.Status", enumChunk.Name);
+        Assert.Equal("public", enumChunk.AccessModifiers);
+        Assert.True(enumChunk.Metadata.ContainsKey("EnumValues"));
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithStruct_ShouldExtractStructChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public struct Point
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+
+        public Point(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+    }
+}";
+        var testFile = CreateTestFile("TestStruct.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var structChunk = chunks.FirstOrDefault(c => c.Type == "struct");
+        Assert.NotNull(structChunk);
+        Assert.Equal("TestNamespace.Point", structChunk.Name);
+        Assert.Equal("public", structChunk.AccessModifiers);
+
+        // Should also have properties and constructor
+        Assert.Contains(chunks, c => c.Type == "property" && c.ParentName == "Point");
+        Assert.Contains(chunks, c => c.Type == "constructor" && c.ParentName == "Point");
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithRecord_ShouldExtractRecordChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public record Person(string FirstName, string LastName)
+    {
+        public int Age { get; set; }
+    }
+}";
+        var testFile = CreateTestFile("TestRecord.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var recordChunk = chunks.FirstOrDefault(c => c.Type == "record");
+        Assert.NotNull(recordChunk);
+        Assert.Equal("TestNamespace.Person", recordChunk.Name);
+        Assert.Equal("public", recordChunk.AccessModifiers);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithNestedClass_ShouldExtractNestedClassChunk()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public class OuterClass
+    {
+        public class NestedClass
+        {
+            public void NestedMethod()
+            {
+            }
+        }
+    }
+}";
+        var testFile = CreateTestFile("NestedClass.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var outerClassChunk = chunks.FirstOrDefault(c => c.Type == "class" && c.Name == "TestNamespace.OuterClass");
+        Assert.NotNull(outerClassChunk);
+
+        var nestedClassChunk = chunks.FirstOrDefault(c => c.Type == "class" && c.Name == "OuterClass.NestedClass");
+        Assert.NotNull(nestedClassChunk);
+        Assert.Equal("OuterClass", nestedClassChunk.ParentName);
+
+        var nestedMethodChunk = chunks.FirstOrDefault(c => c.Type == "method" && c.Name == "OuterClass.NestedClass.NestedMethod");
+        Assert.NotNull(nestedMethodChunk);
+        Assert.Equal("OuterClass.NestedClass", nestedMethodChunk.ParentName);
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithSyntaxErrors_ShouldLogWarningsAndContinue()
+    {
+        // Arrange
+        var sourceCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(
+        {
+            // Missing closing parenthesis in method declaration
+        }
+    }
+}";
+        var testFile = CreateTestFile("SyntaxErrors.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        // Should still extract some chunks despite syntax errors
+        Assert.NotNull(chunks);
+        // The service should continue parsing even with syntax errors
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithComplexFile_ShouldExtractAllChunks()
+    {
+        // Arrange
+        var sourceCode = @"
+using System;
+using System.Collections.Generic;
+
+namespace TestNamespace
+{
+    public class ComplexClass : IDisposable
+    {
+        private readonly string _name;
+        public event EventHandler<string> NameChanged;
+
+        public ComplexClass(string name)
+        {
+            _name = name;
+        }
+
+        public string Name 
+        { 
+            get => _name;
+            set 
+            {
+                _name = value;
+                NameChanged?.Invoke(this, value);
+            }
+        }
+
+        public void DoSomething()
+        {
+            Console.WriteLine(_name);
+        }
+
+        public void Dispose()
+        {
+            // Cleanup
+        }
+    }
+
+    public interface ITestInterface
+    {
+        void TestMethod();
+    }
+
+    public enum TestEnum
+    {
+        Value1,
+        Value2
+    }
+}";
+        var testFile = CreateTestFile("ComplexFile.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        Assert.NotNull(chunks);
+        Assert.True(chunks.Count >= 8); // At least class, field, event, constructor, property, 2 methods, interface, enum
+
+        // Verify all types are present
+        Assert.Contains(chunks, c => c.Type == "class");
+        Assert.Contains(chunks, c => c.Type == "constructor");
+        Assert.Contains(chunks, c => c.Type == "property");
+        Assert.Contains(chunks, c => c.Type == "method");
+        Assert.Contains(chunks, c => c.Type == "interface");
+        Assert.Contains(chunks, c => c.Type == "enum");
+        Assert.Contains(chunks, c => c.Type == "field");
+        Assert.Contains(chunks, c => c.Type == "event");
+
+        // Verify all chunks have valid line numbers
+        foreach (var chunk in chunks)
+        {
+            Assert.True(chunk.StartLine > 0);
+            Assert.True(chunk.EndLine >= chunk.StartLine);
+            Assert.Equal(testFile, chunk.FilePath);
+        }
+    }
+
+    [Fact]
+    public void ParseCSharpFile_WithTopLevelProgram_ShouldHandleCorrectly()
+    {
+        // Arrange
+        var sourceCode = @"
+using System;
+
+Console.WriteLine(""Hello World"");
+
+public class TopLevelClass
+{
+    public void Method()
+    {
+    }
+}";
+        var testFile = CreateTestFile("TopLevelProgram.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        Assert.NotNull(chunks);
+        var classChunk = chunks.FirstOrDefault(c => c.Type == "class");
+        Assert.NotNull(classChunk);
+        Assert.Equal("TopLevelClass", classChunk.Name);
+    }
+
+    [Theory]
+    [InlineData("public")]
+    [InlineData("private")]
+    [InlineData("protected")]
+    [InlineData("internal")]
+    [InlineData("public static")]
+    [InlineData("private readonly")]
+    public void ParseCSharpFile_WithVariousAccessModifiers_ShouldExtractCorrectly(string accessModifier)
+    {
+        // Arrange
+        var sourceCode = $@"
+namespace TestNamespace
+{{
+    public class TestClass
+    {{
+        {accessModifier} string TestField = ""test"";
+    }}
+}}";
+        var testFile = CreateTestFile($"AccessModifier_{accessModifier.Replace(" ", "_")}.cs", sourceCode);
+
+        // Act
+        var chunks = _codeParsingService.ParseCSharpFile(testFile);
+
+        // Assert
+        var fieldChunk = chunks.FirstOrDefault(c => c.Type == "field");
+        Assert.NotNull(fieldChunk);
+        Assert.Equal(accessModifier, fieldChunk.AccessModifiers);
+    }
+
+    private string CreateTestFile(string fileName, string content)
+    {
+        var filePath = Path.Combine(_testFilesDirectory, fileName);
+        File.WriteAllText(filePath, content);
+        return filePath;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testFilesDirectory))
+            {
+                Directory.Delete(_testFilesDirectory, true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors in tests
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new core data model for representing semantic chunks of code and updates project references to support its usage. The primary focus is on improving how code elements are described and tracked within the system.

### Core Model Addition

* Added a new `CodeChunk` class in `Models/CodeChunk.cs` to represent semantic code elements, including properties for type, name, content, file location, line numbers, parent/namespace, dependencies, access modifiers, and metadata. This model will help structure and analyze code at a granular level.

### Project Reference Updates

* Added a reference to `CodeSleuth.Core` in the unit test project (`CodeSleuth.Tests.Unit.csproj`) to enable testing of core models and logic.
* Included the `Microsoft.Extensions.Logging.Abstractions` NuGet package in `CodeSleuth.Core.csproj` to support logging abstractions for future extensibility.